### PR TITLE
[#31] Added buttons to the mod menu.

### DIFF
--- a/Menus/ModMenu.cs
+++ b/Menus/ModMenu.cs
@@ -7,7 +7,8 @@ namespace SpeedrunMod.Menus;
 
 public static class ModMenu
 {
-    private static bool _outdated = (!MyPluginInfo.PLUGIN_VERSION.Equals(VersionText.NewestVersion) && VersionText.NewestVersion != null);
+    private static readonly bool Outdated = !MyPluginInfo.PLUGIN_VERSION.Equals(VersionText.NewestVersion) && VersionText.NewestVersion != null;
+    
     public static void CreateMenu(GameMenu menu)
     {
         GameMenu practiceMenu = PracticeMenu.CreateMenu(menu);
@@ -25,7 +26,7 @@ public static class ModMenu
             .BuildMenuDivider();
         
         new MenuOptionFactory()
-            .SetName(name: _outdated?"INSTALL LATEST VERSION FROM GITHUB":"GITHUB PAGE")
+            .SetName(name: Outdated ? "INSTALL LATEST VERSION FROM GITHUB" : "GITHUB PAGE")
             .SetParent(menu)
             .PlaceOptionBefore(menu.MenuOptions.Count - 1)
             .SetNextLocation(menu)
@@ -36,8 +37,8 @@ public static class ModMenu
     private static void OpenGithub()
     {
         Application.OpenURL(
-            url: _outdated
+            url: Outdated
                 ? $"https://github.com/SliceCraft/MiSideSpeedrunMod/releases/tag/{VersionText.NewestVersion}"
-                : $"https://github.com/SliceCraft/MiSideSpeedrunMod");
+                : "https://github.com/SliceCraft/MiSideSpeedrunMod");
     }
 }

--- a/Menus/ModMenu.cs
+++ b/Menus/ModMenu.cs
@@ -7,6 +7,7 @@ namespace SpeedrunMod.Menus;
 
 public static class ModMenu
 {
+    private static bool _outdated = (!MyPluginInfo.PLUGIN_VERSION.Equals(VersionText.NewestVersion) && VersionText.NewestVersion != null);
     public static void CreateMenu(GameMenu menu)
     {
         GameMenu practiceMenu = PracticeMenu.CreateMenu(menu);
@@ -22,40 +23,21 @@ public static class ModMenu
             .SetParent(menu)
             .PlaceOptionBefore(menu.MenuOptions.Count - 1)
             .BuildMenuDivider();
-        //The text inside the button could be changed to be shorter - Erik
-        if (!MyPluginInfo.PLUGIN_VERSION.Equals(VersionText.NewestVersion) && VersionText.NewestVersion != null)
-        {
-            new MenuOptionFactory()
-                .SetName("INSTALL LATEST VERSION FROM GITHUB")
-                .SetParent(menu)
-                .PlaceOptionBefore(menu.MenuOptions.Count - 1)
-                .SetNextLocation(menu)
-                .SetOnClick(OpenGithub)
-                .Build();
-        }
-        else
-        {
-            new MenuOptionFactory()
-                .SetName("GITHUB PAGE")
-                .SetParent(menu)
-                .PlaceOptionBefore(menu.MenuOptions.Count - 1)
-                .SetNextLocation(menu)
-                .SetOnClick(OpenGithub)
-                .Build();
-        }
+        
+        new MenuOptionFactory()
+            .SetName(name: _outdated?"INSTALL LATEST VERSION FROM GITHUB":"GITHUB PAGE")
+            .SetParent(menu)
+            .PlaceOptionBefore(menu.MenuOptions.Count - 1)
+            .SetNextLocation(menu)
+            .SetOnClick(OpenGithub)
+            .Build();
     }
     
     private static void OpenGithub()
     {
-        if (!MyPluginInfo.PLUGIN_VERSION.Equals(VersionText.NewestVersion) && VersionText.NewestVersion != null)
-        {
-            Application.OpenURL(
-                url: $"https://github.com/SliceCraft/MiSideSpeedrunMod/releases/tag/{VersionText.NewestVersion}");
-        }
-        else
-        {
-            Application.OpenURL(
-                url: $"https://github.com/SliceCraft/MiSideSpeedrunMod");
-        }
+        Application.OpenURL(
+            url: _outdated
+                ? $"https://github.com/SliceCraft/MiSideSpeedrunMod/releases/tag/{VersionText.NewestVersion}"
+                : $"https://github.com/SliceCraft/MiSideSpeedrunMod");
     }
 }

--- a/Menus/ModMenu.cs
+++ b/Menus/ModMenu.cs
@@ -1,7 +1,8 @@
 ﻿using MenuLib.API;
 using MenuLib.API.Factories;
 using SpeedrunMod.Menus.Practice;
-
+using SpeedrunMod.Utils;
+using UnityEngine;
 namespace SpeedrunMod.Menus;
 
 public static class ModMenu
@@ -9,12 +10,52 @@ public static class ModMenu
     public static void CreateMenu(GameMenu menu)
     {
         GameMenu practiceMenu = PracticeMenu.CreateMenu(menu);
-        
+
         new MenuOptionFactory()
             .SetName("PRACTICE")
             .SetParent(menu)
             .PlaceOptionBefore(menu.MenuOptions.Count - 1)
             .SetNextLocation(practiceMenu)
             .Build();
+        
+        new MenuOptionFactory()
+            .SetParent(menu)
+            .PlaceOptionBefore(menu.MenuOptions.Count - 1)
+            .BuildMenuDivider();
+        //The text inside the button could be changed to be shorter - Erik
+        if (!MyPluginInfo.PLUGIN_VERSION.Equals(VersionText.NewestVersion) && VersionText.NewestVersion != null)
+        {
+            new MenuOptionFactory()
+                .SetName("INSTALL LATEST VERSION FROM GITHUB")
+                .SetParent(menu)
+                .PlaceOptionBefore(menu.MenuOptions.Count - 1)
+                .SetNextLocation(menu)
+                .SetOnClick(OpenGithub)
+                .Build();
+        }
+        else
+        {
+            new MenuOptionFactory()
+                .SetName("GITHUB PAGE")
+                .SetParent(menu)
+                .PlaceOptionBefore(menu.MenuOptions.Count - 1)
+                .SetNextLocation(menu)
+                .SetOnClick(OpenGithub)
+                .Build();
+        }
+    }
+    
+    private static void OpenGithub()
+    {
+        if (!MyPluginInfo.PLUGIN_VERSION.Equals(VersionText.NewestVersion) && VersionText.NewestVersion != null)
+        {
+            Application.OpenURL(
+                url: $"https://github.com/SliceCraft/MiSideSpeedrunMod/releases/tag/{VersionText.NewestVersion}");
+        }
+        else
+        {
+            Application.OpenURL(
+                url: $"https://github.com/SliceCraft/MiSideSpeedrunMod");
+        }
     }
 }


### PR DESCRIPTION
## Added buttons to go to the Github page.
Closes #31 

### Two variations:

1. When the version installed is the newest, it just goes to the main repository page.
![Screenshot 2025-03-14 111944](https://github.com/user-attachments/assets/0e838611-ea78-48b8-a80d-1406a4fb6378)

2. When the version is outdated, it takes you directly to the newest release's download page.
![Screenshot 2025-03-14 105400](https://github.com/user-attachments/assets/73741f40-dd43-4a09-807e-851f0f52d0ea)
> (Broke the version deliveratly for the screenshot. Was testing new ways to show the version text as well)

I'm still not convinced about the text in the button, perhaps a new phrase to make it shorter and more snappy?
