### PR TITLE
[ #2 ] Added text labels to triggers

### DIFF
--- a/Patches/SteamManagerPatch.cs
+++ b/Patches/SteamManagerPatch.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using SpeedrunMod.EventDisplay;
 using SpeedrunMod.Practice;
+using SpeedrunMod.RevealSystems;
 using SpeedrunMod.Toggles;
 using SpeedrunMod.Utils;
 
@@ -18,5 +19,6 @@ internal class SteamManagerPatch
         EnableRunToggle.Update();
         RevealTriggerToggle.Update();
         PracticeManager.Update();
+        Triggers.Update();
     }
 }

--- a/RevealSystems/Triggers.cs
+++ b/RevealSystems/Triggers.cs
@@ -2,12 +2,14 @@
 using System.Linq;
 using SpeedrunMod.EventDisplay;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace SpeedrunMod.RevealSystems
 {
     internal static class Triggers
     {
         private static readonly List<GameObject> GameObjects = new List<GameObject>();
+        private static readonly List<GameObject> Labels = new List<GameObject>();
         private static bool _isRevealing;
         private static readonly int Color = Shader.PropertyToID("_Color");
         private static readonly int Mode = Shader.PropertyToID("_Mode");
@@ -16,7 +18,7 @@ namespace SpeedrunMod.RevealSystems
 
         internal static void RevealTriggers()
         {
-            EventManager.ShowEvent(new ModEvent("Revealing Triggers"));
+            //EventManager.ShowEvent(new ModEvent("Revealing Triggers"));
             HideTriggers();
             _isRevealing = true;
             
@@ -39,47 +41,72 @@ namespace SpeedrunMod.RevealSystems
                 AddTriggerRevealer(gameObject, type);
             }
         }
-        
+
         private static void AddTriggerRevealer(GameObject gameObject, string type)
         {
-            GameObject newObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            newObject.transform.SetParent(gameObject.transform, false);
-            newObject.name = "RevealBox" + gameObject.name;
-            //Currently working on bringing these to life.
-            //GameObject canvasGUI = new GameObject("Canvas " + gameObject.name);
-            //GameObject textGUI = new GameObject("Text " + gameObject.name);
-            //Plugin.Log.LogInfo("Creating canvas and text");
+            // Create a new primitive cube for visualization
+            GameObject newObject = CreateRevealCube(gameObject);
 
-            SetMaterialForObject(newObject, type);
+            // Create and configure a canvas and text for display
+            GameObject canvasGUI = CreateCanvas(gameObject);
+            GameObject textGUI = CreateTextUI(canvasGUI, type, gameObject.name);
             
+            SetMaterialForObject(newObject, type);
             newObject.GetComponent<BoxCollider>().enabled = false;
+
+            //Add the objects to the collections
+            //Plugin.Log.LogInfo("Revealing trigger for " + gameObject.name);
             GameObjects.Add(newObject);
+            Labels.Add(canvasGUI);
+        }
+        private static GameObject CreateRevealCube(GameObject parent)
+        {
+            GameObject newObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            newObject.transform.SetParent(parent.transform, false);
+            newObject.name = "RevealBox" + parent.name;
+            return newObject;
+        }
+        
+        private static GameObject CreateCanvas(GameObject parent)
+        {
+            GameObject canvasGUI = new GameObject("Canvas " + parent.name);
+            canvasGUI.AddComponent<Canvas>();
+            canvasGUI.AddComponent<CanvasScaler>();
+            canvasGUI.AddComponent<GraphicRaycaster>();
+            canvasGUI.GetComponent<Canvas>().renderMode = RenderMode.WorldSpace;
+            canvasGUI.transform.SetParent(parent.transform, false);
+            canvasGUI.transform.localPosition = Vector3.up * .5f;
+            canvasGUI.GetComponent<RectTransform>().localScale = new Vector3(0.01f, 0.01f);
+            return canvasGUI;
+        }
+        
+        private static GameObject CreateTextUI(GameObject parent, string type, string name)
+        {
+            GameObject textGUI = new GameObject("Text " + parent.name);
+            textGUI.transform.SetParent(parent.transform, false);
+            Text text = textGUI.AddComponent<Text>();
+            text.text = type + " : " + name;
+            text.fontSize = 30;
+            text.horizontalOverflow = HorizontalWrapMode.Overflow;
+            text.verticalOverflow = VerticalWrapMode.Overflow;
+            text.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            text.alignment = TextAnchor.MiddleCenter;
+            text.color = GetColorForTrigger(type);
+            text.color = new Color(text.color.r, text.color.g, text.color.b, 1f);
+
+            // Adjust the position, scale, and rotation
+            text.rectTransform.localPosition = Vector3.zero;
+            text.rectTransform.localScale = new Vector3(0.3f, 0.3f, 1);
+            text.rectTransform.rotation = Quaternion.Euler(0, 180, 0);
+            return textGUI;
         }
         
         private static void SetMaterialForObject(GameObject newObject, string type)
         {
             MeshRenderer meshRenderer = newObject.GetComponent<MeshRenderer>();
             Material mat = new Material(Shader.Find("Standard"));
-
-            switch (type)
-            {
-                case "distancecamera":
-                    mat.SetColor(Color, new Color(0.98f, 0.0f, 0.0f, .2f)); break;
-                case "distancecheck":
-                    mat.SetColor(Color, new Color(1f, 0.4f, 0.0f, .2f)); break;
-                case "distancecircle":
-                    mat.SetColor(Color, new Color(0.0f, 0.2f, 0.98f, .2f)); break;
-                case "event":
-                    mat.SetColor(Color, new Color(0.0f, 0.97f, 0.0f, .2f)); break;
-                case "mouseclick":
-                    mat.SetColor(Color, new Color(0.3f, 1f, 1f, .2f)); break;
-                case "mouseevent":
-                    mat.SetColor(Color, new Color(0.99f, 0.9f, 0.0f, .2f)); break;
-                case "teleport":
-                    mat.SetColor(Color, new Color(0.9f, 0.2f, 0.7f, .2f)); break;
-                case "zoom":
-                    mat.SetColor(Color, new Color(0.8f, 0.8f, 0.8f, .2f)); break;
-            }
+            
+            mat.SetColor(Color, GetColorForTrigger(type));
             mat.SetColor("_EmissionColor", mat.color);
             mat.EnableKeyword("_EMISSION");
             
@@ -88,8 +115,27 @@ namespace SpeedrunMod.RevealSystems
             mat.SetInt(DstBlend, (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
             mat.EnableKeyword("_ALPHABLEND_ON");
             mat.renderQueue = 3000;
-
+            //This fucking sucks, please help me
+            //Some objects hide even the labels. It seems to be inconsistent and I can't for the life of me make it work
+            //Perhaps implementing a brand-new shader to make it so we on't have to go thru all these hoops.
+            //newObject.layer = LayerMask.NameToLayer(LayerMask.LayerToName(10));
             meshRenderer.material = mat;
+        }
+        
+        private static Color GetColorForTrigger(string type)
+        {
+            switch (type)
+            {
+                case "distancecamera": return new Color(0.98f, 0.0f, 0.0f, .2f);
+                case "distancecheck": return new Color(1f, 0.4f, 0.0f, .2f);
+                case "distancecircle": return new Color(0.0f, 0.2f, 0.98f, .2f);
+                case "event": return new Color(0.0f, 0.97f, 0.0f, .2f);
+                case "mouseclick": return new Color(0.3f, 1f, 1f, .2f);
+                case "mouseevent": return new Color(0.9f, 0.9f, 0.0f, .2f);
+                case "teleport": return new Color(0.9f, 0.2f, 0.7f, .2f);
+                case "zoom": return new Color(0.8f, 0.8f, 0.8f, .2f);
+                default: return new Color(1f, 1f, 1f, .2f);
+            }
         }
 
         internal static void HideTriggers()
@@ -99,12 +145,31 @@ namespace SpeedrunMod.RevealSystems
             {
                 Object.Destroy(gameObject);
             }
+            foreach (GameObject gameObject in Labels.Where(gameObject => gameObject != null))
+            {
+                Object.Destroy(gameObject);
+            }
             GameObjects.Clear();
+            Labels.Clear();
         }
 
         public static bool IsRevealing()
         {
             return _isRevealing;
+        }
+
+        internal static void Update()
+        {
+            if (_isRevealing)
+            {
+                foreach (var label in Labels)
+                {
+                    if (label != null && label.transform != null && Camera.main != null)
+                    {
+                        label.transform.LookAt(Camera.main.transform);
+                    }
+                }
+            }
         }
     }
 }

--- a/RevealSystems/Triggers.cs
+++ b/RevealSystems/Triggers.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using SpeedrunMod.EventDisplay;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -8,22 +7,19 @@ namespace SpeedrunMod.RevealSystems;
 
 internal static class Triggers
 {
-    internal static class Triggers
-    {
-        private static readonly List<GameObject> GameObjects = new List<GameObject>();
-        private static readonly List<GameObject> Labels = new List<GameObject>();
-        private static bool _isRevealing;
-        private static readonly int Color = Shader.PropertyToID("_Color");
-        private static readonly int Mode = Shader.PropertyToID("_Mode");
-        private static readonly int SrcBlend = Shader.PropertyToID("_SrcBlend");
-        private static readonly int DstBlend = Shader.PropertyToID("_DstBlend");
+    private static readonly List<GameObject> GameObjects = new List<GameObject>();
+    private static readonly List<GameObject> Labels = new List<GameObject>();
+    private static bool _isRevealing;
+    private static readonly int Color = Shader.PropertyToID("_Color");
+    private static readonly int Mode = Shader.PropertyToID("_Mode");
+    private static readonly int SrcBlend = Shader.PropertyToID("_SrcBlend");
+    private static readonly int DstBlend = Shader.PropertyToID("_DstBlend");
 
-        internal static void RevealTriggers()
-        {
-            //EventManager.ShowEvent(new ModEvent("Revealing Triggers"));
-            HideTriggers();
-            _isRevealing = true;
-            
+    internal static void RevealTriggers()
+    {
+        HideTriggers();
+        _isRevealing = true;
+
         ProcessTriggers<Trigger_DistanceCamera>("distancecamera");
         ProcessTriggers<Trigger_DistanceCheck>("distancecheck");
         ProcessTriggers<Trigger_DistanceCircle>("distancecircle");
@@ -33,7 +29,7 @@ internal static class Triggers
         ProcessTriggers<Trigger_Teleport>("teleport");
         ProcessTriggers<Trigger_Zoom>("zoom");
     }
-        
+
     private static void ProcessTriggers<T>(string type) where T : Component
     {
         var objects = Object.FindObjectsByType<T>(FindObjectsInactive.Include, FindObjectsSortMode.None);
@@ -42,140 +38,132 @@ internal static class Triggers
             GameObject gameObject = obj.gameObject;
             AddTriggerRevealer(gameObject, type);
         }
+    }
 
-        private static void AddTriggerRevealer(GameObject gameObject, string type)
-        {
-            // Create a new primitive cube for visualization
-            GameObject newObject = CreateRevealCube(gameObject);
+    private static void AddTriggerRevealer(GameObject gameObject, string type)
+    {
+        // Create a new primitive cube for visualization
+        GameObject newObject = CreateRevealCube(gameObject);
 
-            // Create and configure a canvas and text for display
-            GameObject canvasGUI = CreateCanvas(gameObject);
-            GameObject textGUI = CreateTextUI(canvasGUI, type, gameObject.name);
-            
-            SetMaterialForObject(newObject, type);
-            newObject.GetComponent<BoxCollider>().enabled = false;
+        // Create and configure a canvas and text for display
+        GameObject canvasGUI = CreateCanvas(gameObject);
+        CreateTextUI(canvasGUI, type, gameObject.name);
 
-            //Add the objects to the collections
-            //Plugin.Log.LogInfo("Revealing trigger for " + gameObject.name);
-            GameObjects.Add(newObject);
-            Labels.Add(canvasGUI);
-        }
-        private static GameObject CreateRevealCube(GameObject parent)
-        {
-            GameObject newObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            newObject.transform.SetParent(parent.transform, false);
-            newObject.name = "RevealBox" + parent.name;
-            return newObject;
-        }
-        
-        private static GameObject CreateCanvas(GameObject parent)
-        {
-            GameObject canvasGUI = new GameObject("Canvas " + parent.name);
-            canvasGUI.AddComponent<Canvas>();
-            canvasGUI.AddComponent<CanvasScaler>();
-            canvasGUI.AddComponent<GraphicRaycaster>();
-            canvasGUI.GetComponent<Canvas>().renderMode = RenderMode.WorldSpace;
-            canvasGUI.transform.SetParent(parent.transform, false);
-            canvasGUI.transform.localPosition = Vector3.up * .5f;
-            canvasGUI.GetComponent<RectTransform>().localScale = new Vector3(0.01f, 0.01f);
-            return canvasGUI;
-        }
-        
-        private static GameObject CreateTextUI(GameObject parent, string type, string name)
-        {
-            GameObject textGUI = new GameObject("Text " + parent.name);
-            textGUI.transform.SetParent(parent.transform, false);
-            Text text = textGUI.AddComponent<Text>();
-            text.text = type + " : " + name;
-            text.fontSize = 30;
-            text.horizontalOverflow = HorizontalWrapMode.Overflow;
-            text.verticalOverflow = VerticalWrapMode.Overflow;
-            text.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
-            text.alignment = TextAnchor.MiddleCenter;
-            text.color = GetColorForTrigger(type);
-            text.color = new Color(text.color.r, text.color.g, text.color.b, 1f);
+        SetMaterialForObject(newObject, type);
+        newObject.GetComponent<BoxCollider>().enabled = false;
 
-            // Adjust the position, scale, and rotation
-            text.rectTransform.localPosition = Vector3.zero;
-            text.rectTransform.localScale = new Vector3(0.3f, 0.3f, 1);
-            text.rectTransform.rotation = Quaternion.Euler(0, 180, 0);
-            return textGUI;
-        }
-        
-        private static void SetMaterialForObject(GameObject newObject, string type)
+        //Add the objects to the collections
+        GameObjects.Add(newObject);
+        Labels.Add(canvasGUI);
+    }
+
+    private static GameObject CreateRevealCube(GameObject parent)
+    {
+        GameObject newObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        newObject.transform.SetParent(parent.transform, false);
+        newObject.name = "RevealBox" + parent.name;
+        return newObject;
+    }
+
+    private static GameObject CreateCanvas(GameObject parent)
+    {
+        GameObject canvasGUI = new GameObject("Canvas " + parent.name);
+        canvasGUI.AddComponent<Canvas>();
+        canvasGUI.AddComponent<CanvasScaler>();
+        canvasGUI.AddComponent<GraphicRaycaster>();
+        canvasGUI.GetComponent<Canvas>().renderMode = RenderMode.WorldSpace;
+        canvasGUI.transform.SetParent(parent.transform, false);
+        canvasGUI.transform.localPosition = Vector3.up * .5f;
+        canvasGUI.GetComponent<RectTransform>().localScale = new Vector3(0.01f, 0.01f);
+        return canvasGUI;
+    }
+
+    private static GameObject CreateTextUI(GameObject parent, string type, string name)
+    {
+        GameObject textGUI = new GameObject("Text " + parent.name);
+        textGUI.transform.SetParent(parent.transform, false);
+        Text text = textGUI.AddComponent<Text>();
+        text.text = type + " : " + name;
+        text.fontSize = 30;
+        text.horizontalOverflow = HorizontalWrapMode.Overflow;
+        text.verticalOverflow = VerticalWrapMode.Overflow;
+        text.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+        text.alignment = TextAnchor.MiddleCenter;
+        text.color = GetColorForTrigger(type);
+        text.color = new Color(text.color.r, text.color.g, text.color.b, 1f);
+
+        // Adjust the position, scale, and rotation
+        text.rectTransform.localPosition = Vector3.zero;
+        text.rectTransform.localScale = new Vector3(0.3f, 0.3f, 1);
+        text.rectTransform.rotation = Quaternion.Euler(0, 180, 0); 
+        return textGUI;
+    }
+
+    private static void SetMaterialForObject(GameObject newObject, string type)
+    {
+        MeshRenderer meshRenderer = newObject.GetComponent<MeshRenderer>();
+        Material mat = new Material(Shader.Find("Standard"));
+
+        mat.SetColor(Color, GetColorForTrigger(type));
+        mat.SetColor("_EmissionColor", mat.color);
+        mat.EnableKeyword("_EMISSION");
+
+        mat.SetFloat(Mode, 3);
+        mat.SetInt(SrcBlend, (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
+        mat.SetInt(DstBlend, (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+        mat.EnableKeyword("_ALPHABLEND_ON");
+        mat.renderQueue = 3000;
+        //This fucking sucks, please help me
+        //Some objects hide even the labels. It seems to be inconsistent and I can't for the life of me make it work
+        //Perhaps implementing a brand-new shader to make it so we on't have to go through all these hoops.
+        //newObject.layer = LayerMask.NameToLayer(LayerMask.LayerToName(10));
+        meshRenderer.material = mat;
+    }
+
+    private static Color GetColorForTrigger(string type)
+    {
+        switch (type)
         {
-            MeshRenderer meshRenderer = newObject.GetComponent<MeshRenderer>();
-            Material mat = new Material(Shader.Find("Standard"));
-            
-            mat.SetColor(Color, GetColorForTrigger(type));
-            mat.SetColor("_EmissionColor", mat.color);
-            mat.EnableKeyword("_EMISSION");
-            
-            mat.SetFloat(Mode, 3);
-            mat.SetInt(SrcBlend, (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
-            mat.SetInt(DstBlend, (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
-            mat.EnableKeyword("_ALPHABLEND_ON");
-            mat.renderQueue = 3000;
-            //This fucking sucks, please help me
-            //Some objects hide even the labels. It seems to be inconsistent and I can't for the life of me make it work
-            //Perhaps implementing a brand-new shader to make it so we on't have to go thru all these hoops.
-            //newObject.layer = LayerMask.NameToLayer(LayerMask.LayerToName(10));
-            meshRenderer.material = mat;
+            case "distancecamera": return new Color(0.98f, 0.0f, 0.0f, .2f);
+            case "distancecheck": return new Color(1f, 0.4f, 0.0f, .2f);
+            case "distancecircle": return new Color(0.0f, 0.2f, 0.98f, .2f);
+            case "event": return new Color(0.0f, 0.97f, 0.0f, .2f);
+            case "mouseclick": return new Color(0.3f, 1f, 1f, .2f);
+            case "mouseevent": return new Color(0.9f, 0.9f, 0.0f, .2f);
+            case "teleport": return new Color(0.9f, 0.2f, 0.7f, .2f);
+            case "zoom": return new Color(0.8f, 0.8f, 0.8f, .2f);
+            default: return new Color(1f, 1f, 1f, .2f);
         }
-        
-        private static Color GetColorForTrigger(string type)
-        {
-            switch (type)
-            {
-                case "distancecamera": return new Color(0.98f, 0.0f, 0.0f, .2f);
-                case "distancecheck": return new Color(1f, 0.4f, 0.0f, .2f);
-                case "distancecircle": return new Color(0.0f, 0.2f, 0.98f, .2f);
-                case "event": return new Color(0.0f, 0.97f, 0.0f, .2f);
-                case "mouseclick": return new Color(0.3f, 1f, 1f, .2f);
-                case "mouseevent": return new Color(0.9f, 0.9f, 0.0f, .2f);
-                case "teleport": return new Color(0.9f, 0.2f, 0.7f, .2f);
-                case "zoom": return new Color(0.8f, 0.8f, 0.8f, .2f);
-                default: return new Color(1f, 1f, 1f, .2f);
-            }
-        }
+    }
 
     internal static void HideTriggers()
-    {
+    { 
         _isRevealing = false;
         foreach (GameObject gameObject in GameObjects.Where(gameObject => gameObject != null))
         {
-            _isRevealing = false;
-            foreach (GameObject gameObject in GameObjects.Where(gameObject => gameObject != null))
-            {
-                Object.Destroy(gameObject);
-            }
-            foreach (GameObject gameObject in Labels.Where(gameObject => gameObject != null))
-            {
-                Object.Destroy(gameObject);
-            }
-            GameObjects.Clear();
-            Labels.Clear();
-        }
-        GameObjects.Clear();
-    }
-      
-        public static bool IsRevealing()
-        {
-            return _isRevealing;
+            Object.Destroy(gameObject);
         }
 
-        internal static void Update()
+        foreach (GameObject gameObject in Labels.Where(gameObject => gameObject != null))
         {
-            if (_isRevealing)
-            {
-                foreach (var label in Labels)
-                {
-                    if (label != null && label.transform != null && Camera.main != null)
-                    {
-                        label.transform.LookAt(Camera.main.transform);
-                    }
-                }
-            }
+            Object.Destroy(gameObject);
+        }
+
+        GameObjects.Clear();
+        Labels.Clear();
+        }
+
+    public static bool IsRevealing()
+    { 
+        return _isRevealing;
+    }
+
+    internal static void Update()
+    {
+        if (!_isRevealing) return;
+        foreach (var label in Labels.Where(label => label != null && label.transform != null && Camera.main != null))
+        {
+            label.transform.LookAt(Camera.main.transform);
         }
     }
 }

--- a/Toggles/RevealTriggerToggle.cs
+++ b/Toggles/RevealTriggerToggle.cs
@@ -8,6 +8,7 @@ internal static class RevealTriggerToggle
     internal static void Update()
     {
         if (!UnityEngine.Input.GetKey(UnityEngine.KeyCode.LeftAlt) || !UnityEngine.Input.GetKeyDown(UnityEngine.KeyCode.O)) return;
+        Plugin.Log.LogInfo("Toggling trigger");
         if (Triggers.IsRevealing())
         {
             EventManager.ShowEvent(new ModEvent("Trigger Toggle turned off"));

--- a/Toggles/RevealTriggerToggle.cs
+++ b/Toggles/RevealTriggerToggle.cs
@@ -8,15 +8,16 @@ internal static class RevealTriggerToggle
     internal static void Update()
     {
         if (!UnityEngine.Input.GetKey(UnityEngine.KeyCode.LeftAlt) || !UnityEngine.Input.GetKeyDown(UnityEngine.KeyCode.O)) return;
-        Plugin.Log.LogInfo("Toggling trigger");
         if (Triggers.IsRevealing())
         {
             EventManager.ShowEvent(new ModEvent("Trigger Toggle turned off"));
+            Plugin.Log.LogInfo("Toggling on show trigger");
             Triggers.HideTriggers();
         }
         else
         {
             EventManager.ShowEvent(new ModEvent("Trigger Toggle turned on"));
+            Plugin.Log.LogInfo("Toggling off show trigger");
             Triggers.RevealTriggers();
         }
     }


### PR DESCRIPTION
# Add text labels to triggers
Solves [ #2 ]

- Revamped some parts of the Trigger Reaveal Systems code, to keep it reaadable and consisntent with new additions.
- Added text labels to all triggers using the format: **type of trigger** + **name of trigger**.
- Colored the labels using the same color scheme as the triggers to keep things consistent and visible (mainly when overlapping triggers).

> Commented sections of code can be deleted safely

### Showcase:

#### Properly shown labels

![Screenshot 2025-03-24 122404](https://github.com/user-attachments/assets/f180bde5-be3d-4d15-816e-d7a4a2505a78)

![Screenshot 2025-03-24 122801](https://github.com/user-attachments/assets/cc4fc39f-74d2-4645-8c34-cf4e9df4c5b0)

![Screenshot 2025-03-24 122927](https://github.com/user-attachments/assets/a1422988-c264-4c79-869b-75dae6aaa719)

-----------

#### Labels being cut off by their trigger

![Screenshot 2025-03-24 123504](https://github.com/user-attachments/assets/bf606019-c5e0-4899-af73-10547352c84f)

![Screenshot 2025-03-24 122903](https://github.com/user-attachments/assets/dfc358ef-3722-4d5d-90f3-966d38bc8bc6)

-----------

#### Labels not being shown

![image](https://github.com/user-attachments/assets/d2890201-bffa-4d3f-a64a-a9ad4c19a0a3)

 ---------

## Potential issues
> This section is just here to outline some problems with the current way of doing this. It's not a bad way of doing this sort of work, but can for sure be improved upon in later versions as needed. That's to say any future issues created from this implementation can be set to low priority.

While this adds what was requested from the issue outlined, some things stood out as potentially troublesome and that might need to be improve on going foward:

- Having two lists of gameObjects is tax comsuming (Triggers and Canvas).
- Having a lot of canvas' in worldspace loaded can bring issues in some areas dense with triggers (needs testing).
- Some text labels just don't appear and some others clip behin the trigger, although this is inconsisntent.
- If the game is updated out of the current Unity version, legacy text will need to be swapped out with new TextMesh.

### Potential future work:

- [ ] Add a menu option or a key toggle to hide/show text labels when showing triggers
- [ ] Add a menu option or a key toggle to show text labels in the trigger's color or plain white
- [ ] Update the legacy text usage to TextMeshPro
- [ ] Consitently show labels and ensure they are always visible behind any obtruction (at a certain distance)
- [ ] Reimplement this as a screenoverlay instead of worldspace canvas to reduce amount of objects spawned.