### PR TITLE
Version text prefix

### DIFF
--- a/Utils/VersionText.cs
+++ b/Utils/VersionText.cs
@@ -49,12 +49,6 @@ internal static class VersionText
         {
             text.text = $"Slice's Speedrun Mod : V{MyPluginInfo.PLUGIN_VERSION}";
         }
-        //What is being destroyed here?
-        /*Localization_UIText uiText = speedrunVersionText.GetComponent<Localization_UIText>();
-        if (uiText != null)
-        {
-            Object.Destroy(uiText);
-        }*/
     }
 
     private static GameObject GetNameGameObject(GameObject menu)

--- a/Utils/VersionText.cs
+++ b/Utils/VersionText.cs
@@ -42,19 +42,19 @@ internal static class VersionText
         Text text = speedrunVersionText.GetComponent<Text>();
         if (!MyPluginInfo.PLUGIN_VERSION.Equals(NewestVersion) && NewestVersion != null)
         {
-            text.text = $"Speedrun Mod V{MyPluginInfo.PLUGIN_VERSION} : Version outdated, newest version is V{NewestVersion}";
+            text.text = $"Slice's Speedrun Mod V{MyPluginInfo.PLUGIN_VERSION} : Version outdated, newest is V{NewestVersion}";
             text.resizeTextForBestFit = true;
         }
         else
         {
-            text.text = $"Speedrun Mod : V{MyPluginInfo.PLUGIN_VERSION}";
+            text.text = $"Slice's Speedrun Mod : V{MyPluginInfo.PLUGIN_VERSION}";
         }
-
-        Localization_UIText uiText = speedrunVersionText.GetComponent<Localization_UIText>();
+        //What is being destroyed here?
+        /*Localization_UIText uiText = speedrunVersionText.GetComponent<Localization_UIText>();
         if (uiText != null)
         {
             Object.Destroy(uiText);
-        }
+        }*/
     }
 
     private static GameObject GetNameGameObject(GameObject menu)


### PR DESCRIPTION
Brought back the "Slice's" prefix to the version text without comrpomising reability and ensuring it fits in the text box.

I personally think you deserve the recognition plus having the name be there differiantiates it from other future Speedrunning tools if there ever are any.

Also, I deleted the UI text gameobject being destroyed if it existed. I couldn't figure out what it did. If it is nessesary, it can be rolled back.