### PR TITLE
Add optional Cappie ring wait skip

### DIFF
--- a/Configs/ModConfig.cs
+++ b/Configs/ModConfig.cs
@@ -5,6 +5,7 @@ namespace SpeedrunMod.Configs;
 internal static class ModConfig
 {
     internal static ConfigEntry<bool> EnableDialogueSkip;
+    internal static ConfigEntry<bool> EnableCappieRingSkip;
 
     internal static void Initialize(ConfigFile configFile)
     {
@@ -13,6 +14,12 @@ internal static class ModConfig
             "EnableDialogueSkip",
             false,
             "Enable the dialogue skip on game startup (NOTE: This value is automatically controlled by the mod)");
+
+        EnableCappieRingSkip = configFile.Bind(
+            "Skips",
+            "EnableCappieRingSkip",
+            true,
+            "Skip the Cappie chapter ring wait.");
 
         FpsConfig.Initialize(configFile);
         RefreshRateConfig.Initialize(configFile);

--- a/Menus/ModMenu.cs
+++ b/Menus/ModMenu.cs
@@ -50,6 +50,15 @@ public static class ModMenu
             .SetNextLocation(debugSettingsMenu)
             .Build();
 
+        GameMenu skipsSettingsMenu = SkipsSettingsMenu.CreateMenu(menu);
+
+        new MenuOptionFactory()
+            .SetName("SKIPS")
+            .SetParent(menu)
+            .PlaceOptionBefore(menu.MenuOptions.Count - 1)
+            .SetNextLocation(skipsSettingsMenu)
+            .Build();
+
         new MenuOptionFactory()
             .SetParent(menu)
             .PlaceOptionBefore(menu.MenuOptions.Count - 1)

--- a/Menus/SkipsSettingsMenu.cs
+++ b/Menus/SkipsSettingsMenu.cs
@@ -1,0 +1,57 @@
+using MenuLib.API;
+using MenuLib.API.Factories;
+using SpeedrunMod.Configs;
+
+namespace SpeedrunMod.Menus;
+
+internal static class SkipsSettingsMenu
+{
+    private static MenuOption _cappieRingSkipOption;
+
+    private static string CappieRingSkipMenuLabel =>
+        ModConfig.EnableCappieRingSkip.Value
+            ? "Cappie ring skip: On"
+            : "Cappie ring skip: Off";
+
+    internal static GameMenu CreateMenu(GameMenu previousMenu)
+    {
+        GameMenu menu = new MenuFactory()
+            .SetTitle("SKIPS")
+            .SetBackButton(previousMenu)
+            .Build();
+
+        _cappieRingSkipOption = new MenuOptionFactory()
+            .SetName(CappieRingSkipMenuLabel)
+            .SetParent(menu)
+            .PlaceOptionBefore(menu.MenuOptions.Count - 1)
+            .SetNextLocation(menu)
+            .SetOnClick(ToggleCappieRingSkip)
+            .Build();
+        
+        return menu;
+    }
+
+    private static void ToggleCappieRingSkip()
+    {
+        ModConfig.EnableCappieRingSkip.Value = !ModConfig.EnableCappieRingSkip.Value;
+        RefreshCappieRingSkipText();
+        Plugin.Log.LogInfo(CappieRingSkipMenuLabel);
+    }
+
+    private static void RefreshCappieRingSkipText()
+    {
+        SetMenuOptionText(_cappieRingSkipOption, CappieRingSkipMenuLabel);
+    }
+
+    private static void SetMenuOptionText(MenuOption menuOption, string text)
+    {
+        if (menuOption == null) return;
+
+        menuOption.Text = text;
+
+        if (menuOption.TextComponent != null)
+        {
+            menuOption.TextComponent.text = text;
+        }
+    }
+}

--- a/Patches/Location7_RingWorkPatch.cs
+++ b/Patches/Location7_RingWorkPatch.cs
@@ -11,6 +11,10 @@ internal class Location7_RingWorkPatch
     [HarmonyPatch("Start")]
     private static void StartPostfix(Location7_RingWork __instance)
     {
+        // TODO: This return should be replaced by version checks, see #60
+        Plugin.Log.LogInfo("Cappie ring wait skip is disabled by force in this version. In the future this skip will be unlocked depending on the version you're playing on");
+        return;
+
         if (!ModConfig.EnableCappieRingSkip.Value)
         {
             return;

--- a/Patches/Location7_RingWorkPatch.cs
+++ b/Patches/Location7_RingWorkPatch.cs
@@ -1,0 +1,30 @@
+using HarmonyLib;
+using SpeedrunMod.Configs;
+using SpeedrunMod.Notifications;
+
+namespace SpeedrunMod.Patches;
+
+[HarmonyPatch(typeof(Location7_RingWork))]
+internal class Location7_RingWorkPatch
+{
+    [HarmonyPostfix]
+    [HarmonyPatch("Start")]
+    private static void StartPostfix(Location7_RingWork __instance)
+    {
+        if (!ModConfig.EnableCappieRingSkip.Value)
+        {
+            return;
+        }
+
+        try
+        {
+            __instance.ReadyTime();
+            Plugin.Log.LogInfo("Cappie ring wait skipped");
+            NotificationManager.Show(new NotificationMessage("Cappie ring wait skipped"));
+        }
+        catch (System.Exception ex)
+        {
+            Plugin.Log.LogError($"Failed to skip Cappie ring wait: {ex}");
+        }
+    }
+}

--- a/SpeedrunMod.csproj
+++ b/SpeedrunMod.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>SliceCraft.SpeedrunMod</AssemblyName>
     <Product>SpeedrunMod</Product>
-    <Version>1.4.1-beta.1-cappie-ring-skip</Version>
+    <Version>1.4.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RestoreAdditionalProjectSources>

--- a/SpeedrunMod.csproj
+++ b/SpeedrunMod.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>SliceCraft.SpeedrunMod</AssemblyName>
     <Product>SpeedrunMod</Product>
-    <Version>1.4.0</Version>
+    <Version>1.4.1-beta.1-cappie-ring-skip</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RestoreAdditionalProjectSources>


### PR DESCRIPTION
Closes #56 

Adds skip for Cappie chapter ring wait (~6 min idle). Same approach as [KappiMod RingInstantReadyPatch](https://github.com/MrSago/MiSide-KappiMod): Harmony postfix on `Location7_RingWork.Start` calls `ReadyTime()` when enabled