### PR TITLE
 Moved notifications to the bottom right corner + minor bug fixes

### DIFF
--- a/Configs/RefreshRateConfig.cs
+++ b/Configs/RefreshRateConfig.cs
@@ -55,7 +55,7 @@ internal static class RefreshRateConfig
             return _cachedRefreshRateHz;
         }
 
-        return OverrideTarget.Value;
+        return GetTargetHz();
     }
 
     internal static int GetTargetHz()

--- a/Notifications/NotificationManager.cs
+++ b/Notifications/NotificationManager.cs
@@ -10,6 +10,9 @@ internal static class NotificationManager
     private static GameObject _hintScreenTemplate;
 
     private static GameObject _interfaceObject;
+
+    private static float? _bottomMargin;
+    private static float? _rightMargin;
     
     private static readonly List<TimedNotification> TimedNotifications = 
     [
@@ -27,7 +30,8 @@ internal static class NotificationManager
             return false;
         }
 
-        GameObject go = Object.Instantiate(_hintScreenTemplate, _interfaceObject.gameObject.transform);
+        GameObject go = Object.Instantiate(_hintScreenTemplate);
+        go.transform.SetParent(_interfaceObject.transform, false);
 
         Text text = go.GetComponentInChildren<Text>();
         text.text = notificationMessage.Text;
@@ -45,9 +49,20 @@ internal static class NotificationManager
         for (int i = NotificationObjects.Count - 1; i >= 0; i--)
         {
             GameObject go = NotificationObjects[i].HintObject;
-            Vector3 pos = go.transform.position;
-            pos.y = i * 100 + 100;
-            go.transform.position = pos;
+            if (go == null)
+            {
+                continue;
+            }
+
+            if (go.TryGetComponent(out RectTransform rectTransform))
+            {
+                var bottomMargin = _bottomMargin ?? 0f;
+                var rightMargin = _rightMargin ?? 0f;
+                rectTransform.anchorMin = new Vector2(1f, 0f);
+                rectTransform.anchorMax = new Vector2(1f, 0f);
+                rectTransform.pivot = new Vector2(1f, 0f);
+                rectTransform.anchoredPosition = new Vector2(rightMargin, i * 100f + bottomMargin);
+            }
         }
     }
 
@@ -170,6 +185,18 @@ internal static class NotificationManager
 
         _interfaceObject = interfaceObject;
         _hintScreenTemplate = hintScreenObject;
+
+        if (_bottomMargin != null && _rightMargin != null)
+        {
+            return true;
+        }
+
+        if (_hintScreenTemplate.TryGetComponent(out RectTransform templateRect))
+        {
+            _bottomMargin = -templateRect.anchoredPosition.y;
+            _rightMargin = -templateRect.anchoredPosition.x;
+        }
+
         return true;
     }
 }

--- a/Notifications/NotificationManager.cs
+++ b/Notifications/NotificationManager.cs
@@ -31,9 +31,23 @@ internal static class NotificationManager
         }
 
         GameObject go = Object.Instantiate(_hintScreenTemplate);
+
+        if (go == null)
+        {
+            Plugin.Log.LogWarning("Tried instantiating hint screen template but was unable to find it.");
+            return false;
+        }
+
         go.transform.SetParent(_interfaceObject.transform, false);
 
         Text text = go.GetComponentInChildren<Text>();
+
+        if (text == null)
+        {
+            Plugin.Log.LogWarning("Tried getting text component but was unable to find it.");
+            return false;
+        }
+
         text.text = notificationMessage.Text;
 
         notificationMessage.HintObject = go;
@@ -46,7 +60,9 @@ internal static class NotificationManager
 
     private static void UpdatePositions()
     {
-        for (int i = NotificationObjects.Count - 1; i >= 0; i--)
+        NotificationObjects.RemoveAll(static n => n.HintObject == null);
+
+        for (int i = 0; i < NotificationObjects.Count; i++)
         {
             GameObject go = NotificationObjects[i].HintObject;
             if (go == null)

--- a/Notifications/RefreshRateNotification.cs
+++ b/Notifications/RefreshRateNotification.cs
@@ -11,7 +11,7 @@ internal sealed class RefreshRateNotification : TimedNotification
     
     protected override void Initialize()
     {
-        SceneLoadedEvent.SceneLoaded += (_, _) => Show();
+        SceneLoadedEvent.SceneLoaded += (_, _) => Show(force: true);
     }
 
     protected override NotificationMessage GetNotification()

--- a/Notifications/TimedNotification.cs
+++ b/Notifications/TimedNotification.cs
@@ -39,22 +39,17 @@ internal abstract class TimedNotification
         Show();
     }
     
-    public void Show()
+    public void Show(bool force = false)
     {
         EnsureInitialized();
 
         float now = Time.realtimeSinceStartup;
-        if (!IsAllowed(now))
+        if (now < _nextAllowedShowAt && !force)
         {
             return;
         }
 
         ShowNotification(now);
-    }
-
-    private bool IsAllowed(float now)
-    {
-        return now >= _nextAllowedShowAt;
     }
 
     protected void ShowNotification(float now)

--- a/SpeedrunMod.csproj
+++ b/SpeedrunMod.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>SliceCraft.SpeedrunMod</AssemblyName>
     <Product>SpeedrunMod</Product>
-    <Version>1.4.1-beta.1-notification-layout</Version>
+    <Version>1.4.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RestoreAdditionalProjectSources>

--- a/SpeedrunMod.csproj
+++ b/SpeedrunMod.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>SliceCraft.SpeedrunMod</AssemblyName>
     <Product>SpeedrunMod</Product>
-    <Version>1.4.0</Version>
+    <Version>1.4.1-beta.1-notification-layout</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RestoreAdditionalProjectSources>

--- a/Utils/GameUtil.cs
+++ b/Utils/GameUtil.cs
@@ -4,22 +4,9 @@ namespace SpeedrunMod.Utils;
 
 internal static class GameUtil
 {
-    private static GameController _cachedGameController;
-    private static float _gameControllerExpiry;
-
     internal static GameController GetGameController()
     {
-        const float ttlSeconds = 5f;
-
-        var now = Time.realtimeSinceStartup;
-        if (now < _gameControllerExpiry)
-        {
-            return _cachedGameController;
-        }
-
-        _cachedGameController = Object.FindObjectOfType<GameController>();
-        _gameControllerExpiry = now + ttlSeconds;
-        return _cachedGameController;
+        return Object.FindObjectOfType<GameController>();
     }
 
     internal static bool IsInGame() => GetGameController() != null;

--- a/Utils/GameUtil.cs
+++ b/Utils/GameUtil.cs
@@ -4,9 +4,38 @@ namespace SpeedrunMod.Utils;
 
 internal static class GameUtil
 {
+    private static GameController _cachedGameController;
+    private static float _gameControllerExpiry;
+
     internal static GameController GetGameController()
     {
-        return Object.FindObjectOfType<GameController>();
+        const float ttlSeconds = 5f;
+        var now = Time.realtimeSinceStartup;
+
+        void Refresh()
+        {
+            _cachedGameController = Object.FindObjectOfType<GameController>();
+            _gameControllerExpiry = now + ttlSeconds;
+        }
+
+        if (_cachedGameController == null)
+        {
+            // GameController is null only when we are still in the main menu.
+            // So we need to refresh the cached game controller
+            // ignoring the TTL, until the game starts.
+            // This ensures that at the start of the game
+            // callers don't have to wait for the TTL to expire.
+            Refresh();
+            return _cachedGameController;
+        }
+
+        if (now < _gameControllerExpiry)
+        {
+            return _cachedGameController;
+        }
+
+        Refresh();
+        return _cachedGameController;
     }
 
     internal static bool IsInGame() => GetGameController() != null;


### PR DESCRIPTION
Closes #58 

- Moved notifications to the bottom-right corner to prevent overlap with KappieMod notifications and the photomode menu.
- Fixed a bug where refresh rate notifications sometimes wouldn't appear on chapter load. Notifications are now forced to display, and the GameController cache has been removed, as it could occasionally prevent notifications from firing.
- Fixed the refresh rate value returned by GetActualHz(). It now returns the correct clamped value from GetTargetHz() instead of the raw config value.